### PR TITLE
README: add DEVMEM to required kconfigs

### DIFF
--- a/README
+++ b/README
@@ -70,6 +70,7 @@
     Setup involves some minor kernel configuration
 
     The following kernel build options are required for all kernels:
+        CONFIG_DEVMEM=y
         CONFIG_PM_DEBUG=y
         CONFIG_PM_SLEEP_DEBUG=y
         CONFIG_FTRACE=y


### PR DESCRIPTION
While DEVMEM is a kconfig default in the x86_64_defconfig, it is not
necessarily the default in distro kernels (e.g. Clear Linux), so call it
out.

Signed-off-by: Joe Konno <joe.konno@intel.com>