### PR TITLE
Upgrade to python3

### DIFF
--- a/bootgraph.py
+++ b/bootgraph.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0-only
 #
 # Tool for analyzing boot timing

--- a/sleepgraph.py
+++ b/sleepgraph.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0-only
 #
 # Tool for analyzing suspend/resume timing


### PR DESCRIPTION
Since python2 is EOL'ed in Yocto, upgrading to python3 is needed for the layers that use pm-graph to build without locally applying a patch.
 
Signed-off-by: Chanakya Koppolu <chanakya.koppolu@intel.com>