### PR TITLE
sleepgraph: add support for RT kernel ftrace flags

### DIFF
--- a/sleepgraph.py
+++ b/sleepgraph.py
@@ -2792,7 +2792,7 @@ class TestProps:
 		'[ +!#\*@$]*(?P<dur>[0-9\.]*) .*\|  (?P<msg>.*)'
 	ftrace_line_fmt_nop = \
 		' *(?P<proc>.*)-(?P<pid>[0-9]*) *\[(?P<cpu>[0-9]*)\] *'+\
-		'(?P<flags>.{4}) *(?P<time>[0-9\.]*): *'+\
+		'(?P<flags>.{4,7}) *(?P<time>[0-9\.]*): *'+\
 		'(?P<msg>.*)'
 	machinesuspend = 'machine_suspend\[.*'
 	def __init__(self):


### PR DESCRIPTION
with PREEMPT_RT enabled in kernel, ftrace have a different
flags format:

                   _-----=> irqs-off
                  / _----=> need-resched
                 | / _----=> need-resched
                 || / _---=> hardirq/softirq
                 ||| / _--=> preempt-depth
                 ||||/     delay
TASK-PID   CPU#  |||||   TIMESTAMP  FUNCTION
   | |       |   |||||      |         |

add support for this.

Signed-off-by: Liwei Song <liwei.song@windriver.com>