### PR TITLE
sleepgraph.py: parse unfished cpu exec line

### DIFF
--- a/sleepgraph.py
+++ b/sleepgraph.py
@@ -3365,8 +3365,21 @@ def parseTraceLog(live=False):
 					val = ps.split()
 					if not val:
 						continue
-					name = val[0].replace('--', '-')
-					proclist[name] = int(val[1])
+					if not len(val) < 2:
+						name = val[0].replace('--', '-')
+						proclist[name] = int(val[1])
+					else:
+						proclist = dict()
+						nextline = next(tf)
+						mcont = re.match(tp.ftrace_line_fmt, nextline)
+						n = m.group('ps') + mcont.group('msg').split(': ')[1]
+						for pscont in n.split(','):
+							val = pscont.split()
+							if not val:
+								continue
+							if not len(val) < 2:
+								name = val[0].replace('--', '-')
+								proclist[name] = int(val[1])
 				data.pstl[t.time] = proclist
 				continue
 		# find the end of resume


### PR DESCRIPTION
exist the below case in ftrace file:
sleepgraph-6508    [003] .... 18197.824037: tracing_mark_write: ps - xxx..., lock_torture_wr-94 169,lock_torture_wr-95 143,lock_tort
sleepgraph-6508    [003] .... 18197.824043: tracing_mark_write: ure_wr-96 189,lock_torture_wr-97 174,lock_torture_wr-98 160,lock_torture_st-99 1

lock_torture_wr-96 was split to different line due to limited buffer
size(1k) set in kernel, check this case and re-parse the unfinished
line.

Signed-off-by: Liwei Song <liwei.song@windriver.com>